### PR TITLE
Added Quarkus RabbitMQ Client documentation project to the sources list

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -11,6 +11,9 @@ content:
   - url: https://github.com/quarkiverse/quarkus-github-app.git
     branches: [master]
     start_path: docs
+  - url: https://github.com/quarkiverse/quarkus-rabbitmq-client.git
+    branches: [master]
+    start_path: docs 
 ui:
   bundle:
     url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/master/raw/build/ui-bundle.zip?job=bundle-stable


### PR DESCRIPTION
Added the Quarkus RabbitMQ Client documentation to the sources list. Master for now has the basic content, but once the first release is done proper documentation will show up.