### PR TITLE
Allow to navigate between Quarkiverse  extensions via an index module

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -1,10 +1,12 @@
 site:
   title: Quarkiverse Documentation
   url: https://quarkiverse.github.io/quarkiverse-docs/
-  start_page: quarkiverse-freemarker::index.adoc
+  start_page: index::index.adoc
 
 content:
   sources:
+    - url: . # common module containing just the main index
+      branches: HEAD
     - url: https://github.com/quarkiverse/quarkus-freemarker.git
       branches: [master]
       start_path: docs

--- a/antora.yml
+++ b/antora.yml
@@ -1,0 +1,4 @@
+# Descriptor of the common Antora module that contains just a landing page for the whole documentation site
+name: index
+title: Index
+version: index

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,0 +1,5 @@
+= Quarkiverse documentation
+
+Welcome to the Quarkiverse documentation site. 
+
+Pick the Quarkus extension you're interested in from the navigation menu.

--- a/supplemental-ui/partials/header-content.hbs
+++ b/supplemental-ui/partials/header-content.hbs
@@ -22,9 +22,9 @@
         <div class="navbar-item has-dropdown is-hoverable">
           <div class="navbar-link">Projects</div>
           <div class="navbar-dropdown">
-            <div class="navbar-item"><strong>Docs</strong></div>
-            <a class="navbar-item" href="https://github.com/quarkiverse/quarkiverse-docs">Repository</a>
-            <a class="navbar-item" href="https://github.com/quarkiverse/quarkiverse-docs/issues">Issue Tracker</a>
+{{#each site.components}}
+            <a class="navbar-item" href="{{{relativize ./latestVersion/url}}}">{{{./title}}}</a>
+{{/each}}
           </div>
         </div>
         <div class="navbar-item has-dropdown is-hoverable">


### PR DESCRIPTION
Here's an attempt to fix the lack of navigation, inspired by https://github.com/smallrye/smallrye.github.io/tree/develop/docs

- Avoid going to freemarker extension by default when targeting https://quarkiverse.github.io/quarkiverse-docs/
- Add a welcome page with list of extensions in left menu
- Allow to navigate between extensions via Projects dropdown