### PR TITLE
Register quarkus-logging-splunk docs

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -28,6 +28,9 @@ content:
     - url: https://github.com/quarkiverse/quarkus-cxf.git
       branches: [ master ]
       start_path: docs
+    - url: https://github.com/quarkiverse/quarkus-logging-splunk.git
+      branches: [ main ]
+      start_path: docs
 
 ui:
   bundle:


### PR DESCRIPTION
Registering the doc associated to extension https://github.com/quarkiverse/quarkus-logging-splunk