### PR TITLE
Add Kerberos Docs

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -46,6 +46,9 @@ content:
     - url: https://github.com/quarkiverse/quarkus-cucumber
       branches: HEAD
       start_path: docs
+    - url: https://github.com/quarkiverse/quarkus-kerberos
+      branches: HEAD
+      start_path: docs
 ui:
   bundle:
     url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/master/raw/build/ui-bundle.zip?job=bundle-stable


### PR DESCRIPTION
CC @aloubyansky @stuartwdouglas 

Right now README at https://github.com/quarkiverse/quarkus-kerberos points to the non-existent page