### PR TITLE
Add the documentation of Quarkus Groovy

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -204,7 +204,10 @@ content:
       start_path: docs
     - url: https://github.com/quarkiverse/quarkus-zeebe
       branches: [HEAD, 0.x]
-      start_path: docs      
+      start_path: docs
+    - url: https://github.com/quarkiverse/quarkus-groovy.git
+      branches: HEAD
+      start_path: docs            
 ui:
   bundle:
     url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable


### PR DESCRIPTION
I would like to add the documentation of Quarkus Groovy to https://quarkiverse.github.io/quarkiverse-doc