### PR TITLE
Use new-style URL as antora canonical URL to try and resolve broken 404 page

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -1,6 +1,6 @@
 site:
   title: Quarkiverse Documentation
-  url: https://quarkiverse.github.io/quarkiverse-docs/
+  url: https://docs.quarkiverse.io
   start_page: index::index.adoc
 
 content:


### PR DESCRIPTION
@gsmet pointed out that our 404 page is missing styling. See, for example, https://docs.quarkiverse.io/nope. 

I was briefly puzzled, because when I checked the Antora UI project, the 404 page was styled nicely. It was also styled nicely if I looked at the docs site locally. 

It turns out the problem is a bad interaction between the path prefix and the cname, which means the stylesheet can’t be found. You can see this more clearly by clicking on one of the links on a 404, which give links of the form https://docs.quarkiverse.io/quarkiverse-docs/quarkus-amazon-alexa/dev/index.html. So we also need to fix that too!

When you build locally, antora constructs different URLs, which makes debugging hard.

On functioning pages, this is the stylesheet link (it’s relative)

`<link rel="stylesheet" href="../../_/css/site.css">`

On the bad pages, this is the link (it’s root-relative):

`<link rel="stylesheet" href="/quarkiverse-docs/_/css/site.css">`

It’s the same pattern for the content links.

I’ve updated the [antora site url](https://docs.antora.org/antora/latest/playbook/site-url/), which may fix this by stopping antora adding a `/quarkiverse-docs` to urls it constructs. Fixing the url isn’t a bad thing to do, even if it doesn't fix the 404 page. 