### PR TITLE
Use node.js version 18

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Install packages
         run: npm i


### PR DESCRIPTION
keep same version for both: https://github.com/quarkiverse/quarkiverse-docs/blob/a4477b2ccf2dc2a827e937a4c021320291054065/.github/workflows/publish.yml#L50