### PR TITLE
Register quarkus-kafka-streams-processor doc

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -130,6 +130,9 @@ content:
     - url: https://github.com/quarkiverse/quarkus-jsch
       branches: HEAD
       start_path: docs
+    - url: https://github.com/quarkiverse/quarkus-kafka-streams-processor.git
+      branches: HEAD
+      start_path: docs
     - url: https://github.com/quarkiverse/quarkus-kerberos
       branches: HEAD
       start_path: docs


### PR DESCRIPTION
Registering the doc associated to extension https://github.com/quarkiverse/quarkus-kafka-streams-processor