### PR TITLE
remove non-quarkiverse from the index

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -7,9 +7,6 @@ content:
   sources: # Keep in alphabetical order by URL
     - url: . # common module containing just the main index
       branches: HEAD
-    - url: https://github.com/kiota-community/kiota-java-extra
-      branches: HEAD
-      start_path: docs
     - url: https://github.com/quarkiverse/quarkus-amazon-alexa
       branches: HEAD
       start_path: docs


### PR DESCRIPTION
pushing this as draft/suggestion.

why is kiota that is external to quarkiverse hub added to this index?

seems wrong/bad/inconsistent to have non quarkiverse hub doc content hosted here.

extensions.quarkus.io is able to link to external doc sites.