### PR TITLE
Use refname projection as version for Quarkus Amazon Service

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -11,7 +11,9 @@ content:
       branches: HEAD
       start_path: docs
     - url: https://github.com/quarkiverse/quarkus-amazon-services
-      branches: [ HEAD, 1.x, 2.4.x, 2.12.x ]
+      branches: [ HEAD, '{1..9}*({0..9})?(.+({0..9})).x' ]
+      version: 
+        HEAD: dev # fallback to using the matched refname as the value for other branches
       start_path: docs
     - url: https://github.com/quarkiverse/quarkus-antivirus
       branches: HEAD


### PR DESCRIPTION
This PR make use of the [refname projection feature](https://docs.antora.org/antora/latest/component-version-key/#refname-projection) to remove the need to maintain a version attribute in each branch.

I will remove the version attribute from the different content source branches when merged.
