### PR TITLE
Add url for search.quarkus.io to be used in the templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://docs.quarkiverse.io",
   "private": true,
   "scripts": {
-    "build": "antora antora-playbook.yml"
+    "build": "_SEARCH_SERVICE_HOST='https://search.quarkus.io' antora antora-playbook.yml"
   },
   "dependencies": {
     "antora": "~3.1.10",


### PR DESCRIPTION
required for https://github.com/quarkiverse/antora-ui-quarkiverse/pull/70

The theme template uses an environment variable for the search service, which should be defined when the site is built.