### PR TITLE
Automatically alphabetise antora yaml after changes

### DIFF
--- a/.github/workflows/alphabetise.yml
+++ b/.github/workflows/alphabetise.yml
@@ -29,6 +29,8 @@ jobs:
           mv antora-playbook-sorted.yml antora-playbook.yml
 
       - name: Create Pull Request
+        # Skip main in forks
+        if: "github.repository == 'quarkiverse/quarkiverse-docs' && endsWith(github.ref, '/main')"
         run: |
           git checkout -b alpha-${{ github.run_id }}
           git add antora-playbook.yml

--- a/.github/workflows/alphabetise.yml
+++ b/.github/workflows/alphabetise.yml
@@ -32,14 +32,9 @@ jobs:
 
       - name: Alphabetise
         id: alpha
-        uses: mikefarah/yq@master
-        with:
-          path: antora-playbook.yml
-          cmd: '.content.sources |= sort_by(.url)'
-
-      - name: Overwite file
         run: |
-          echo ${{ steps.alpha.outputs.result }} > antora-playbook.yml
+          yq '.content.sources |= sort_by(.url)' antora-playbook.yml > antora-playbook-sorted.yml
+          mv antora-playbook-sorted.yml antora-playbook.yml
 
       - name: Create Pull Request
         run: |

--- a/.github/workflows/alphabetise.yml
+++ b/.github/workflows/alphabetise.yml
@@ -22,14 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Install packages
-        run: npm install -g yaml-sort
-
       - name: Alphabetise
         id: alpha
         run: |

--- a/.github/workflows/alphabetise.yml
+++ b/.github/workflows/alphabetise.yml
@@ -36,13 +36,16 @@ jobs:
         with:
           path: antora-playbook.yml
           cmd: '.content.sources |= sort_by(.url)'
+
       - name: Overwite file
         run: |
           echo ${{ steps.alpha.outputs.result }} > antora-playbook.yml
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
-        with:
-          commit-message: Automatic alphabetisation
-          add-paths: |
-            antora-playbook.yml
+        run: |
+          git checkout -b alpha-${{ github.run_id }}
+          git add antora-playbook.yml
+          git commit -m "Automatic alphabetisation"
+          git push
+          gh pr create --title "Automatic alphabetisation"
+

--- a/.github/workflows/alphabetise.yml
+++ b/.github/workflows/alphabetise.yml
@@ -47,5 +47,7 @@ jobs:
           git add antora-playbook.yml
           git commit -m "Automatic alphabetisation"
           git push
-          gh pr create --title "Automatic alphabetisation"
+          gh pr create --title "Automatic alphabetisation" --fill --repo quarkiverse/quarkiverse-docs
+       env:
+       	  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/alphabetise.yml
+++ b/.github/workflows/alphabetise.yml
@@ -47,7 +47,7 @@ jobs:
           git add antora-playbook.yml
           git commit -m "Automatic alphabetisation"
           git push
-          gh pr create --title "Automatic alphabetisation" --fill --repo quarkiverse/quarkiverse-docs
-       env:
-       	  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          gh pr create --title "Automatic alphabetisation" --fill --repo $GITHUB_REPOSITORY
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/alphabetise.yml
+++ b/.github/workflows/alphabetise.yml
@@ -1,0 +1,48 @@
+name: Alphabetise extension list
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - antora-playbook.yml
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install packages
+        run: npm install -g yaml-sort
+
+      - name: Alphabetise
+        id: alpha
+        uses: mikefarah/yq@master
+        with:
+          path: antora-playbook.yml
+          cmd: '.content.sources |= sort_by(.url)'
+      - name: Overwite file
+        run: |
+          echo ${{ steps.alpha.outputs.result }} > antora-playbook.yml
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: Automatic alphabetisation
+          add-paths: |
+            antora-playbook.yml


### PR DESCRIPTION
Resolves #161. 

As always with workflow changes, this is hard to test. I de-sorted a local copy of the yaml and have run my script locally on the current yaml file. The output is included in this PR. You can see it tidied up a few trailing whitespaces, which is no bad thing, IMO. The comment removal was mine, since I didn't think we needed it anymore. 

After sorting, the script raises a PR with changes. We could use something like https://github.com/marketplace/actions/git-auto-commit instead, but I thought we should start cautious. :) 

After merging, I expect this will run successfully, but not create any PRs. To get the first PR, we'll need to wait for the next extension which adds documentation (and gets the order wrong). 