### PR TITLE
Add upstream to github command

### DIFF
--- a/.github/workflows/alphabetise.yml
+++ b/.github/workflows/alphabetise.yml
@@ -32,10 +32,10 @@ jobs:
         # Skip main in forks
         if: "github.repository == 'quarkiverse/quarkiverse-docs' && endsWith(github.ref, '/main')"
         run: |
-          git checkout -b alpha-${{ github.run_id }}
+          git checkout -b sorting-${{ github.run_id }}
           git add antora-playbook.yml
           git commit -m "Automatic alphabetisation"
-          git push
+          git push --set-upstream origin sorting-${{ github.run_id }}
           gh pr create --title "Automatic alphabetisation" --fill --repo $GITHUB_REPOSITORY
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
```
Run git checkout -b alpha-10309392019
Switched to a new branch 'alpha-10309392019'
[alpha-10309392019 8ac5628] Automatic alphabetisation
 1 file changed, 28 insertions(+), 31 deletions(-)
fatal: The current branch alpha-10309392019 has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin alpha-10309392019

To have this happen automatically for branches without a tracking
upstream, see 'push.autoSetupRemote' in 'git help config'.
```

😢 