### PR TITLE
Remove quarkus-payara-qube Doc from Antora

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -315,9 +315,6 @@ content:
     - url: https://github.com/quarkiverse/quarkus-pact.git
       branches: [HEAD, quarkus-2-support]
       start_path: docs
-    - url: https://github.com/quarkiverse/quarkus-payara-qube.git
-      branches: [HEAD]
-      start_path: docs
     - url: https://github.com/quarkiverse/quarkus-pdfbox.git
       branches: HEAD
       start_path: docs


### PR DESCRIPTION
Payara Qube is deprecated, so the docs.