### PR TITLE
Add quarkus-http-idempotency to the docs playbook

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -153,6 +153,9 @@ content:
     - url: https://github.com/quarkiverse/quarkus-hivemq-client
       branches: HEAD
       start_path: docs
+    - url: https://github.com/quarkiverse/quarkus-http-idempotency
+      branches: HEAD
+      start_path: docs
     - url: https://github.com/quarkiverse/quarkus-infinispan-embedded
       branches: HEAD
       start_path: docs


### PR DESCRIPTION
Hi Quarkiverse team! 👋

The [quarkus-http-idempotency](https://github.com/quarkiverse/quarkus-http-idempotency) extension recently joined Quarkiverse, and its docs aren't published yet because the project isn't listed in the playbook. This adds it as a content source so its documentation shows up at `docs.quarkiverse.io/quarkus-http-idempotency/dev`.

The repo already ships the standard Antora docs module (`docs/antora.yml` with `version: dev`, `nav.adoc`, `index.adoc`, and an auto-generated config reference via `quarkus-config-doc-maven-plugin`), so a single `HEAD` content source is all that's needed for now. I'll add a `tags:` entry once the first release is out.

The entry is placed in alphabetical order, between `quarkus-hivemq-client` and `quarkus-infinispan-embedded`.

Thanks a lot for maintaining the docs site, and happy to adjust anything if needed!