### PR TITLE
Add quarkus-snappy to the Antora playbook

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -393,6 +393,9 @@ content:
     - url: https://github.com/quarkiverse/quarkus-smallrye-opentracing
       branches: HEAD
       start_path: docs
+    - url: https://github.com/quarkiverse/quarkus-snappy
+      branches: HEAD
+      start_path: docs
     - url: https://github.com/quarkiverse/quarkus-solr
       branches: HEAD
       start_path: docs


### PR DESCRIPTION
Registers quarkus-snappy (https://github.com/quarkiverse/quarkus-snappy) as an Antora content source. The repo has a `docs/` module set up correctly, but it was never added to `antora-playbook.yml`, so its documentation has never been picked up by docs.quarkiverse.io.