### PR TITLE
docs: quarkus-zeebe -> quarkus-camunda rename

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -66,6 +66,9 @@ content:
     - url: https://github.com/quarkiverse/quarkus-chicory
       branches: HEAD
       start_path: docs
+    - url: https://github.com/quarkiverse/quarkus-camunda
+      branches: [HEAD, 1.x, 0.x]
+      start_path: docs
     - url: https://github.com/quarkiverse/quarkus-config-extensions
       branches: HEAD
       start_path: docs
@@ -424,9 +427,6 @@ content:
       start_path: docs
     - url: https://github.com/quarkiverse/quarkus-zanzibar.git
       branches: HEAD
-      start_path: docs
-    - url: https://github.com/quarkiverse/quarkus-zeebe
-      branches: [HEAD, 0.x]
       start_path: docs
     - url: https://github.com/quarkiverse/quarkus-zookeeper-client
       branches: HEAD


### PR DESCRIPTION
Hey, 
not entirely sure about this one ... but I noticed search complaining that it cannot find the default docs for zeebe anymore, and I tracked that down to the extension rename...

> search.quarkus.io indexing status: WARNING
WARNING
Issues with PARSING:
Cannot find latest version of Quarkiverse Docs within /tmp/quarkiverse-io3064659355314618122/pages/quarkus-zeebe

see also: 
- https://github.com/quarkiverse/quarkus-camunda/commit/4e43a03ce9bb9739d115632a41d88bd9261b205b
- https://github.com/quarkusio/search.quarkus.io/issues/130#issuecomment-4986516402