### PR TITLE
Add quarkus-banner to the documentation playbook

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -48,6 +48,9 @@ content:
     - url: https://github.com/quarkiverse/quarkus-backstage
       branches: HEAD
       start_path: docs
+    - url: https://github.com/quarkiverse/quarkus-banner
+      branches: HEAD
+      start_path: docs
     - url: https://github.com/quarkiverse/quarkus-barcode
       branches: HEAD
       start_path: docs


### PR DESCRIPTION
Adds the [quarkus-banner](https://github.com/quarkiverse/quarkus-banner) extension to the Antora playbook so its documentation is published to https://docs.quarkiverse.io/quarkus-banner.

Inserted alphabetically by URL (between `quarkus-backstage` and `quarkus-barcode`).